### PR TITLE
Fix deaths registering twice when inside of a car

### DIFF
--- a/src/main/java/com/useful/ucars/uCarsListener.java
+++ b/src/main/java/com/useful/ucars/uCarsListener.java
@@ -1158,12 +1158,9 @@ public class uCarsListener implements Listener {
 	/*
 	 * This disables fall damage whilst driving a car
 	 */
-	@EventHandler(priority = EventPriority.HIGHEST)
+	@EventHandler(priority = EventPriority.HIGHEST, ignoreCancelled = true)
 	void safeFly(EntityDamageEvent event) {
-		if (!(event.getEntity() instanceof Player)) {
-			return;
-		}
-		if (event.isCancelled()) {
+		if (!(event.getEntity() instanceof Player) || event.getCause() != DamageCause.FALL) {
 			return;
 		}
 		Player p = (Player) event.getEntity();


### PR DESCRIPTION
This is a fix for deaths registering twice whilst dying inside of a car by someone else. If someone killed you with a sword and you were riding in a car it will show 2 deaths rather then one. Not sure why, but I assume it has to do with using damageable and damaging the player. This might not be an issue on 1.7, but tested on 1.8.3 as an issue.