### PR TITLE
Fixing Teleports + Multiworld-Update

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -133,5 +133,5 @@
     <properties>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     </properties>
-    <version>25</version>
+    <version>1.16-R1.0.0</version>
 </project>

--- a/pom.xml
+++ b/pom.xml
@@ -133,5 +133,5 @@
     <properties>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     </properties>
-    <version>24</version>
+    <version>25</version>
 </project>

--- a/pom.xml
+++ b/pom.xml
@@ -133,5 +133,5 @@
     <properties>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     </properties>
-    <version>1.16-R1.0.0</version>
+    <version>1.16-R1.1.0</version>
 </project>

--- a/src/main/java/com/useful/ucars/PlaceManager.java
+++ b/src/main/java/com/useful/ucars/PlaceManager.java
@@ -33,6 +33,7 @@ public class PlaceManager {
 	}
 	
 	public static Boolean placeableOn(Block block, ucars plugin) {
+		if (ucars.listener.getWorldList().contains(block.getWorld().getName()))
 		if (!ucars.config.getBoolean("general.cars.roadBlocks.enable")) {
 			return true;
 		}

--- a/src/main/java/com/useful/ucars/uCarsListener.java
+++ b/src/main/java/com/useful/ucars/uCarsListener.java
@@ -78,6 +78,7 @@ public class uCarsListener implements Listener {
 	private Boolean usePerms = false;
 	private Boolean fuelEnabled = false;
 	private Boolean fuelUseItems = false;
+	private Boolean disableFallDamage = false;
 	
 	private double defaultSpeed = 30;
 	private static double defaultHealth = 10;
@@ -1134,7 +1135,7 @@ public class uCarsListener implements Listener {
 							if (!ch.isLoaded()) {
 								ch.load(true);
 							}
-							player.teleport(toTele.clone().add(0,2,0));
+							player.teleport(toTele.clone().add(0,1,0));
 							uCarRespawnEvent evnt = new uCarRespawnEvent(car, carId, car.getUniqueId(),
 									CarRespawnReason.TELEPORT);
 							plugin.getServer().getPluginManager().callEvent(evnt);
@@ -1217,6 +1218,9 @@ public class uCarsListener implements Listener {
 					y = 1.05;
 					// ascend stairs
 				}
+				if (car.getFallDistance() > 1.5) { //Prevents Fall Distance stacking up causing fall-damage when climbing longer slopes
+					y = y*0.95;
+				}
 				Boolean ignore = false;
 				if (car.getVelocity().getY() > 4) {
 					// if car is going up already then don't do ascent
@@ -1269,7 +1273,7 @@ public class uCarsListener implements Listener {
 	}
 
 	/*
-	 * This disables fall damage whilst driving a car
+	 * This disables minor fall damage whilst driving a car
 	 */
 	@EventHandler(priority = EventPriority.HIGHEST, ignoreCancelled = true)
 	void safeFly(EntityDamageEvent event) {
@@ -1277,18 +1281,17 @@ public class uCarsListener implements Listener {
 			return;
 		}
 		Player p = (Player) event.getEntity();
-		if (inACar(p.getName())) {
-			event.setCancelled(true);
-			/*Vector vel = p.getVehicle().getVelocity();
-			if (!(vel.getY() > -0.1 && vel.getY() < 0.1)) {
-			} else {
+		if (inACar(p.getName()) && !disableFallDamage) {
+			Vector vel = p.getVehicle().getVelocity();
+			if (vel.getY() > -0.1 && vel.getY() < 0.1) {
+				event.setCancelled(true);
+			}/*else {
 				try {
 					p.damage(event.getDamage());
 				} catch (Exception e) {
 					// Damaging failed
 				}
 			}*/
-
 		}
 		return;
 	}
@@ -2132,6 +2135,7 @@ public class uCarsListener implements Listener {
 		effectBlocksEnabled = ucars.config.getBoolean("general.cars.effectBlocks.enable");
 		fuelEnabled = ucars.config.getBoolean("general.cars.fuel.enable");
 		fuelUseItems = ucars.config.getBoolean("general.cars.fuel.items.enable");
+		disableFallDamage = ucars.config.getBoolean("general.cars.fallDamageDisabled");
 		
 		if(roadBlocksEnabled){
 		    List<String> ids = ucars.config

--- a/src/main/java/com/useful/ucars/uCarsListener.java
+++ b/src/main/java/com/useful/ucars/uCarsListener.java
@@ -1281,17 +1281,21 @@ public class uCarsListener implements Listener {
 			return;
 		}
 		Player p = (Player) event.getEntity();
-		if (inACar(p.getName()) && !disableFallDamage) {
-			Vector vel = p.getVehicle().getVelocity();
-			if (vel.getY() > -0.1 && vel.getY() < 0.1) {
+		if (inACar(p.getName())) {
+			if(!disableFallDamage) {
+				Vector vel = p.getVehicle().getVelocity();
+				if (vel.getY() > -0.1 && vel.getY() < 0.1) {
+					event.setCancelled(true);
+				}/*else {
+					try {
+						p.damage(event.getDamage());
+					} catch (Exception e) {
+						// Damaging failed
+					}
+				}*/
+			} else {
 				event.setCancelled(true);
-			}/*else {
-				try {
-					p.damage(event.getDamage());
-				} catch (Exception e) {
-					// Damaging failed
-				}
-			}*/
+			}
 		}
 		return;
 	}

--- a/src/main/java/com/useful/ucars/uCarsListener.java
+++ b/src/main/java/com/useful/ucars/uCarsListener.java
@@ -1086,11 +1086,6 @@ public class uCarsListener implements Listener {
 				if (s != null) {
 					String[] lines = s.getLines();
 					if (lines[0].equalsIgnoreCase("[Teleport]")) {
-						Boolean raceCar = false;
-						if (car.hasMetadata("kart.racing")
-								|| UEntityMeta.hasMetadata(car, "kart.racing")) {
-							raceCar = true;
-						}
 						UEntityMeta.setMetadata(car, "safeExit.ignore", new StatValue(null, plugin));
 						
 						String xs = lines[1];
@@ -1133,17 +1128,13 @@ public class uCarsListener implements Listener {
 							
 							UUID carId = car.getUniqueId();
 							
-							Location toTele = new Location(s.getWorld(), x,
+							final Location toTele = new Location(s.getWorld(), x,
 									y, z);
 							Chunk ch = toTele.getChunk();
-							if (ch.isLoaded()) {
+							if (!ch.isLoaded()) {
 								ch.load(true);
 							}
-							car.teleport(toTele);
-							UEntityMeta.setMetadata(car, "carhealth", health);
-							if (raceCar) {
-								UEntityMeta.setMetadata(car, "kart.racing", new StatValue(null, plugin));
-							}
+							player.teleport(toTele.clone().add(0,2,0));
 							uCarRespawnEvent evnt = new uCarRespawnEvent(car, carId, car.getUniqueId(),
 									CarRespawnReason.TELEPORT);
 							plugin.getServer().getPluginManager().callEvent(evnt);
@@ -1156,6 +1147,7 @@ public class uCarsListener implements Listener {
 								Bukkit.getScheduler().runTaskLater(plugin, new Runnable(){
 									@Override
 									public void run() {
+										ucar.teleport(toTele);
 										ucar.addPassenger(player); //For the sake of uCarsTrade
 										return;
 									}}, 2l);
@@ -1286,10 +1278,10 @@ public class uCarsListener implements Listener {
 		}
 		Player p = (Player) event.getEntity();
 		if (inACar(p.getName())) {
-			Vector vel = p.getVehicle().getVelocity();
+			event.setCancelled(true);
+			/*Vector vel = p.getVehicle().getVelocity();
 			if (!(vel.getY() > -0.1 && vel.getY() < 0.1)) {
-				event.setCancelled(true);
-			} /*else {
+			} else {
 				try {
 					p.damage(event.getDamage());
 				} catch (Exception e) {

--- a/src/main/java/com/useful/ucars/uCarsListener.java
+++ b/src/main/java/com/useful/ucars/uCarsListener.java
@@ -72,6 +72,7 @@ public class uCarsListener implements Listener {
 	private Boolean carsEnabled = true;
 	private Boolean licenseEnabled = false;
 	private Boolean roadBlocksEnabled = false;
+	private Boolean multiverseEnabled = false;
 	private Boolean trafficLightsEnabled = true;
 	private Boolean effectBlocksEnabled = true;
 	private Boolean usePerms = false;
@@ -97,6 +98,7 @@ public class uCarsListener implements Listener {
     private List<String> jumpBlock = new ArrayList<String>(); //Jump blocks (Iron)
     private List<String> teleportBlock = new ArrayList<String>(); //Teleport blocks (purple clay)
     private List<String> barriers = new ArrayList<String>();
+    private List<String> ucarworlds = new ArrayList<String>();
     
     private ConcurrentHashMap<String, Double> speedMods = new ConcurrentHashMap<String, Double>();
 
@@ -194,12 +196,16 @@ public class uCarsListener implements Listener {
 		if(cart.hasMetadata("ucars.ignore") || UEntityMeta.hasMetadata(cart, "ucars.ignore")){
 			return false; //Not a car
 		}
+		if(multiverseEnabled && !ucarworlds.contains(cart.getWorld().getName())) {
+			return false;
+		}
 		if((cart.getType().toString().toUpperCase().contains("MINECART") && cart.getType().toString().length() > 8) || cart.getType().toString().toUpperCase().contains("BOAT")) {
 			return false; //Not a car but a Minecart_Something (only useful when derailed)
 		}
 		if(cart instanceof Animals) {
 			return false;	//Animals are not cars...
 		}
+		
 		
 		Location loc = cart.getLocation();
 		Block b = loc.getBlock();
@@ -2129,6 +2135,7 @@ public class uCarsListener implements Listener {
 		
 		licenseEnabled = ucars.config.getBoolean("general.cars.licenses.enable");
 		roadBlocksEnabled = ucars.config.getBoolean("general.cars.roadBlocks.enable");
+		multiverseEnabled = ucars.config.getBoolean("general.cars.worlds.enable");
 		trafficLightsEnabled = ucars.config.getBoolean("general.cars.trafficLights.enable");
 		effectBlocksEnabled = ucars.config.getBoolean("general.cars.effectBlocks.enable");
 		fuelEnabled = ucars.config.getBoolean("general.cars.fuel.enable");
@@ -2147,6 +2154,10 @@ public class uCarsListener implements Listener {
 			ids.add("WATER");
 			ids.add("STATIONARY_WATER");
 			roadBlocks = ids;
+		}
+		if(multiverseEnabled) {
+			ucarworlds.clear();
+			ucarworlds.addAll(ucars.config.getStringList("general.cars.worlds.ids"));
 		}
 		if(trafficLightsEnabled){
 			trafficLightRawIds = ucars.config.getStringList("general.cars.trafficLights.waitingBlock");
@@ -2174,5 +2185,9 @@ public class uCarsListener implements Listener {
 			}
 		}
 		//No longer speedmods
+	}
+	
+	public List<String> getWorldList() {
+		return ucarworlds;
 	}
 }

--- a/src/main/java/com/useful/ucars/ucars.java
+++ b/src/main/java/com/useful/ucars/ucars.java
@@ -435,6 +435,9 @@ public class ucars extends JavaPlugin {
 			if (!config.contains("general.cars.hitBy.damage")) {
 				config.set("general.cars.hitBy.damage", 1.5);
 			}
+			if (!config.contains("general.cars.fallDamageDisabled")) {
+				config.set("general.cars.fallDamageDisabled", false);
+			}
 			if (!config.contains("general.cars.worlds.enable")) {
 				config.set("general.cars.worlds.enable", false);
 			}

--- a/src/main/java/com/useful/ucars/ucars.java
+++ b/src/main/java/com/useful/ucars/ucars.java
@@ -435,6 +435,13 @@ public class ucars extends JavaPlugin {
 			if (!config.contains("general.cars.hitBy.damage")) {
 				config.set("general.cars.hitBy.damage", 1.5);
 			}
+			if (!config.contains("general.cars.worlds.enable")) {
+				config.set("general.cars.worlds.enable", false);
+			}
+			if (!config.contains("general.cars.worlds.ids")) {
+				config.set("general.cars.worlds.ids", new String[]{
+						"world"});
+			}
 			if (!config.contains("general.cars.roadBlocks.enable")) {
 				config.set("general.cars.roadBlocks.enable", false);
 			}

--- a/src/main/resources/plugin.yml
+++ b/src/main/resources/plugin.yml
@@ -1,6 +1,6 @@
 name: uCars
 main: com.useful.ucars.ucars
-version: 25
+version: 25.1
 api-version: 1.13
 softdepend: [Vault]
 depend: [ProtocolLib]

--- a/src/main/resources/plugin.yml
+++ b/src/main/resources/plugin.yml
@@ -1,6 +1,6 @@
 name: uCars
 main: com.useful.ucars.ucars
-version: 24.1
+version: 24.2
 api-version: 1.13
 softdepend: [Vault]
 depend: [ProtocolLib]

--- a/src/main/resources/plugin.yml
+++ b/src/main/resources/plugin.yml
@@ -1,6 +1,6 @@
 name: uCars
 main: com.useful.ucars.ucars
-version: 24.2
+version: 25
 api-version: 1.13
 softdepend: [Vault]
 depend: [ProtocolLib]


### PR DESCRIPTION
Fixing Teleports:
The old code would remove the minecart and spawn in a new one instead of actually teleporting it
This is important as the Metadata would for some reason get corrupted that way.
This issue is fixed.

The big question of ucarstrade - Technically all entities support teleports so this should TECHNICALLY not be a problem.
But maybe I'm missing something here.


Multiworld-Support:
You can enable multiworld-support through the config - default is false (so no changes to running servers)
But they would now have the ability to just enable ucars in specific worlds.